### PR TITLE
Fix git url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 ## How to Run
 
 ```shell
-git clone https://github.com/0xNikilite/oboromi
+git clone https://github.com/0xNikilite/oboromi.git
 cd oboromi
 
 cargo run


### PR DESCRIPTION
Basically the `.git` at the end is forgotten.