### PR TITLE
[gpu] MOV: implement immediate form (mov__RI variant)

### DIFF
--- a/core/src/gpu/sm86.rs
+++ b/core/src/gpu/sm86.rs
@@ -2699,9 +2699,25 @@ impl<'a> Decoder<'a> {
         todo!();
     }
     pub fn mov(&mut self, inst: u128) {
-        let _pg = (((inst >> 12) & 0x7) << 0);
-        let _pg_not = (((inst >> 15) & 0x1) << 0);
-        let _rd = (((inst >> 16) & 0xff) << 0);
+        let pg = (((inst >> 12) & 0x7) << 0) as u32;
+        let pg_not = (((inst >> 15) & 0x1) << 0) as u32;
+        let rd = (((inst >> 16) & 0xff) << 0) as u32;
+
+        // MOV shares one primary opcode across several addressing-mode
+        // variants (register, constant-bank, indexed constant-bank, immediate)
+        // that real hardware disambiguates using bits inside the operand
+        // field itself, not the opcode. Re-derive the same 13-bit selector
+        // the dispatcher used to route here; only the immediate form
+        // (key 0x1a02 / CLASS "mov__RI") is implemented so far.
+        let variant_key = ((((inst >> 91) & 0x1) << 12) | (inst & 0xfff)) as u32;
+        if variant_key == 0x1a02 {
+            // Rd = imm32
+            let imm32 = (((inst >> 32) & 0xffffffff) << 0) as u32;
+            let val = self.cached_const_u32(imm32);
+            self.store_register_predicated(rd, pg, pg_not != 0, val);
+            return;
+        }
+
         let _sc_addr = (((inst >> 40) & 0x3fff) << 0);
         let _sc_bank = (((inst >> 54) & 0x1f) << 0);
         let _pixmasku04 = (((inst >> 72) & 0xf) << 0);

--- a/core/src/tests/gpu_test.rs
+++ b/core/src/tests/gpu_test.rs
@@ -53,6 +53,15 @@ mod inst {
         inst
     }
 
+    // mov rd, imm32 (immediate form, CLASS "mov__RI", key=0x1a02: bit91=1, low12=0xa02)
+    pub fn mov_imm(rd: u32, imm32: u32) -> u128 {
+        let mut inst: u128 = 0xa02;
+        inst |= 1u128 << 91;
+        inst |= ((rd as u128) & 0xff) << 16;
+        inst |= ((imm32 as u128) & 0xffffffff) << 32;
+        inst
+    }
+
     // kill (opcode=0x8e0)
     pub fn kill(pred: u32, invert: bool) -> u128 {
         let mut inst: u128 = 0x8e0;
@@ -130,6 +139,7 @@ pub fn run_gpu_tests() -> Vec<String> {
         run_translation_test("IADD Register", &[inst::iadd_reg(1, 2, 3)]),
         run_translation_test("IADD3 Register", &[inst::iadd3_reg(1, 2, 3, 4)]),
         run_translation_test("IADD32I", &[inst::iadd32i(1, 2, 100)]),
+        run_translation_test("MOV immediate", &[inst::mov_imm(1, 0xCAFEBABE)]),
         run_translation_test("KILL PT", &[inst::kill(7, false)]),
     ];
 


### PR DESCRIPTION
## Description
While looking for a small first contribution, I picked MOV32I since its stub looked similar to the already-implemented IADD32I.
This PR implements just the immediate-load case inside the shared mov() handler, gated on its specific encoding key. The other MOV addressing-mode variants are left as todo!().

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 - [ x ] `cargo test` - full unit test suite passes (6/6). Run with: cargo test
 - [ x ] `GPU decoder translation tests` - the new MOV immediate test (and all existing ones) verified passing by launching the GUI and clicking "Run GPU Tests".

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation (this is an internal decoder detail with no user-facing docs page; the inline comment explaining the opcode ambiguity is the relevant documentation for future contributors)
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published in downstream modules (no dependent changes, this PR is self-contained)
